### PR TITLE
make dynamics' and evolve's handling of `use_basis_gates` and enable their tests to skip transpiler

### DIFF
--- a/qiskit_acqua/dynamics/dynamics.py
+++ b/qiskit_acqua/dynamics/dynamics.py
@@ -39,6 +39,7 @@ class Dynamics(QuantumAlgorithm):
     PROP_PAULIS_GROUPING = 'paulis_grouping'
     PROP_EXPANSION_MODE = 'expansion_mode'
     PROP_EXPANSION_ORDER = 'expansion_order'
+    PROP_USE_BASIS_GATES = 'use_basis_gates'
 
     DYNAMICS_CONFIGURATION = {
         'name': 'Dynamics',
@@ -94,6 +95,10 @@ class Dynamics(QuantumAlgorithm):
                     'default': 1,
                     'minimum': 1
                 },
+                PROP_USE_BASIS_GATES: {
+                    'type': 'boolean',
+                    'default': True
+                }
             },
             'additionalProperties': False
         },
@@ -117,6 +122,7 @@ class Dynamics(QuantumAlgorithm):
         self._paulis_grouping = None
         self._expansion_mode = None
         self._expansion_order = None
+        self._use_basis_gates = None
         self._ret = {}
 
     def init_params(self, params, algo_input):
@@ -145,6 +151,7 @@ class Dynamics(QuantumAlgorithm):
         paulis_grouping = dynamics_params.get(Dynamics.PROP_PAULIS_GROUPING)
         expansion_mode = dynamics_params.get(Dynamics.PROP_EXPANSION_MODE)
         expansion_order = dynamics_params.get(Dynamics.PROP_EXPANSION_ORDER)
+        use_basis_gates = dynamics_params.get(Dynamics.PROP_USE_BASIS_GATES)
 
         # Set up initial state, we need to add computed num qubits to params
         initial_state_params = params.get(QuantumAlgorithm.SECTION_KEY_INITIAL_STATE)
@@ -154,11 +161,13 @@ class Dynamics(QuantumAlgorithm):
 
         self.init_args(
             operator, operator_mode, initial_state, evo_operator, evo_time, num_time_slices,
-            paulis_grouping=paulis_grouping, expansion_mode=expansion_mode, expansion_order=expansion_order
+            paulis_grouping=paulis_grouping, expansion_mode=expansion_mode, expansion_order=expansion_order,
+            use_basis_gates=use_basis_gates
         )
 
-    def init_args(self, operator, operator_mode, initial_state, evo_operator, evo_time, num_time_slices,
-                  paulis_grouping='default', expansion_mode='trotter', expansion_order=1):
+    def init_args(
+            self, operator, operator_mode, initial_state, evo_operator, evo_time, num_time_slices,
+            paulis_grouping='default', expansion_mode='trotter', expansion_order=1, use_basis_gates=True):
         self._operator = operator
         self._operator_mode = operator_mode
         self._initial_state = initial_state
@@ -168,6 +177,7 @@ class Dynamics(QuantumAlgorithm):
         self._paulis_grouping = paulis_grouping
         self._expansion_mode = expansion_mode
         self._expansion_order = expansion_order
+        self._use_basis_gates = use_basis_gates
         self._ret = {}
 
     def run(self):
@@ -182,7 +192,8 @@ class Dynamics(QuantumAlgorithm):
             quantum_registers=quantum_registers,
             paulis_grouping=self._paulis_grouping,
             expansion_mode=self._expansion_mode,
-            expansion_order=self._expansion_order
+            expansion_order=self._expansion_order,
+            use_basis_gates=self._use_basis_gates
         ).data
 
         self._ret['avg'], self._ret['std_dev'] = self._operator.eval(self._operator_mode, qc, self._backend)

--- a/qiskit_acqua/operator.py
+++ b/qiskit_acqua/operator.py
@@ -1238,7 +1238,7 @@ class Operator(object):
             return side + middle + side
 
     def evolve(self, state_in, evo_time, evo_mode, num_time_slices, quantum_registers=None,
-               paulis_grouping='random', expansion_mode='trotter', expansion_order=1):
+               paulis_grouping='random', expansion_mode='trotter', expansion_order=1, use_basis_gates=True):
         """
         Carry out the dynamics evolution for the operator under supplied specifications.
 
@@ -1319,7 +1319,7 @@ class Operator(object):
                             expansion_order
                         )
                 return self.construct_evolution_circuit(
-                    slice_pauli_list, evo_time, num_time_slices, quantum_registers
+                    slice_pauli_list, evo_time, num_time_slices, quantum_registers, use_basis_gates=use_basis_gates
                 )
         else:
             raise ValueError('Evolution mode should be either "matrix" or "circuit".')

--- a/test/test_dynamics.py
+++ b/test/test_dynamics.py
@@ -18,9 +18,6 @@
 import unittest
 
 import numpy as np
-from qiskit import QuantumRegister
-from qiskit.wrapper import execute as q_execute
-from qiskit.tools.qi.qi import state_fidelity
 
 from test.common import QISKitAcquaTestCase
 from qiskit_acqua.operator import Operator
@@ -32,14 +29,7 @@ class TestEvolution(QISKitAcquaTestCase):
 
     def test_evolution(self):
         SIZE = 2
-        #SPARSITY = 0
-        #X = [[0, 1], [1, 0]]
-        #Y = [[0, -1j], [1j, 0]]
-        Z = [[1, 0], [0, -1]]
-        I = [[1, 0], [0, 1]]
-        h1 = np.kron(I, Z)  # + 0.5 * np.kron(Y, X)# + 0.3 * np.kron(Z, X) + 0.4 * np.kron(Z, Y)
 
-        # np.random.seed(2)
         temp = np.random.random((2 ** SIZE, 2 ** SIZE))
         h1 = temp + temp.T
         qubitOp = Operator(matrix=h1)
@@ -55,7 +45,7 @@ class TestEvolution(QISKitAcquaTestCase):
         num_time_slices = 100
 
         dynamics = get_algorithm_instance('Dynamics')
-        dynamics.setup_quantum_backend()
+        dynamics.setup_quantum_backend(skip_transpiler=True)
         # self.log.debug('state_out:\n\n')
 
         dynamics.init_args(qubitOp, 'paulis', state_in, evoOp, evo_time, num_time_slices)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Add `use_basis_gates` flag for the `Operator.evolve()` method, as well as in the `dynamics` algorithm implementation. Set the `skip_transpiler` flags to `True` to corresponding tests.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Being consistent with how `use_basis_gates` and `skip_transplier` are used elsewhere in the project; improve qiskit circuit execution speed.

<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Running/passing all relevant tests included.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.