### PR TITLE
Fix typo grouped paulis

### DIFF
--- a/docs/algorithms.rst
+++ b/docs/algorithms.rst
@@ -67,7 +67,7 @@ Additionally, VQE can be configured with the following parameters:
 
        operator_mode : "matrix" | "paulis" | "grouped_paulis"
 
-   If no value for ``operator_mode`` ia specified, the default is ``"matrix"``. 
+   If no value for ``operator_mode`` ia specified, the default is ``"matrix"``.
 
 -  The initial point for the search of the minimum eigenvalue:
 
@@ -111,25 +111,25 @@ Dynamics can be configured with the following parameter settings:
 -  Evolution time:
 
    .. code:: python
-   
+
        evo_time : float
 
    A number is expected.  The minimum value is ``0.0``.  The default value is ``1.0``.
 
 -  The evolution mode of the computation:
 
-   .. code:: python 
+   .. code:: python
 
        evo_mode = "matrix" | "circuit"
 
    Two ``string`` values are permitted: ``"matrix"`` or ``"circuit"``, with ``"circuit"`` being the default.
 
--  The number of time slices: 
+-  The number of time slices:
 
    .. code:: python
 
        num_time_slices = 0 | 1 | ...
-   
+
    This has to be a non-negative ``int`` value.  The default is ``1``.
 
 -  Paulis grouping mode:
@@ -141,7 +141,7 @@ Dynamics can be configured with the following parameter settings:
    Two ``string`` values are permitted: ``"default"`` or ``"random"``, with ``"default"`` being the default and indicating
    that the paulis should be grouped.
 
--  The expansion mode: 
+-  The expansion mode:
 
    .. code:: python
 
@@ -191,7 +191,7 @@ state <initial_states.html>`__ and an `IQFT <./iqfts.html>`__.
 
 QPE is also configured with the following parameter settings:
 
--  The number of time slices: 
+-  The number of time slices:
 
    .. code:: python
 
@@ -227,7 +227,7 @@ QPE is also configured with the following parameter settings:
 
 -  The number of ancillae:
 
-   .. code:: python 
+   .. code:: python
 
        num_ancillae = 1 | 2 | ...
 

--- a/docs/algorithms.rst
+++ b/docs/algorithms.rst
@@ -65,7 +65,7 @@ Additionally, VQE can be configured with the following parameters:
 
    .. code:: python
 
-       operator_mode : "matrix" | "paulis" | "group_paulis"
+       operator_mode : "matrix" | "paulis" | "grouped_paulis"
 
    If no value for ``operator_mode`` ia specified, the default is ``"matrix"``. 
 

--- a/qiskit_acqua/README.md
+++ b/qiskit_acqua/README.md
@@ -50,7 +50,7 @@ VQE supports the problems: `energy` and `ising`
 
 VQE can be configured with the following parameters:
 
-* `operator_mode`=**matrix** | paulis | group_paulis
+* `operator_mode`=**matrix** | paulis | grouped_paulis
 
   Mode used by the operator.py class for the computation
 


### PR DESCRIPTION
## Description

fix the `operator_mode`'s option value from `group_paulis` to `grouped_paulis`.
please see the following code.
https://github.com/QISKit/qiskit-acqua/blob/master/qiskit_acqua/vqe/vqe.py#L52

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.