### PR TITLE
do not eliminate paulis with zero coefficient during addition

### DIFF
--- a/qiskit_acqua/operator.py
+++ b/qiskit_acqua/operator.py
@@ -87,12 +87,6 @@ class Operator(object):
                 idx = self._paulis_table.get(pauli_label, None)
                 if idx is not None:
                     self._paulis[idx][0] += pauli[0]
-                    if self._paulis[idx][0] == 0.0:
-                        del self._paulis[idx]
-                        self._paulis_table.pop(pauli_label, None)
-                        for k, v in self._paulis_table.items():
-                            if v > idx:
-                                self._paulis_table[k] -= 1
                 else:
                     self._paulis_table[pauli_label] = len(self._paulis)
                     self._paulis.append(pauli)
@@ -138,7 +132,7 @@ class Operator(object):
                         found_pauli = True
                         rhs_coeff = coeff2
                         break
-                if found_pauli == False and rhs_coeff != 0.0: # since we might have 0 weights of paulis.
+                if found_pauli == False and rhs_coeff != 0.0:  # since we might have 0 weights of paulis.
                     return False
                 if coeff != rhs_coeff:
                     return False
@@ -205,22 +199,25 @@ class Operator(object):
 
     def _simplify_paulis(self):
         """
-        Merge the paulis (grouped_paulis) whose bases are identical.
+        Merge the paulis (grouped_paulis) whose bases are identical but the pauli with zero coefficient
+        would not be removed.
+
         Usually used in construction.
         """
         if self._paulis is not None:
-            paulis = []
-            for idx in range(len(self._paulis)):
-                not_found = True
-                for idy in range(len(paulis)):
-                    if self._paulis[idx][1] == paulis[idy][1]:
-                        paulis[idy][0] += self._paulis[idx][0]
-                        not_found = False
-                        break
-                if not_found:
-                    paulis.append(self._paulis[idx])
-            self._paulis = paulis
-            self._paulis_table = {pauli[1].to_label(): i for i, pauli in enumerate(self._paulis)}
+            new_paulis = []
+            new_paulis_table = {}
+            for curr_paulis in self._paulis:
+                pauli_label = curr_paulis[1].to_label()
+                new_idx = new_paulis_table.get(pauli_label, None)
+                if new_idx is not None:
+                    new_paulis[new_idx][0] += curr_paulis[0]
+                else:
+                    new_paulis_table[pauli_label] = len(new_paulis)
+                    new_paulis.append(curr_paulis)
+
+            self._paulis = new_paulis
+            self._paulis_table = new_paulis_table
 
         elif self._grouped_paulis is not None:
             self._grouped_paulis_to_paulis()
@@ -640,7 +637,7 @@ class Operator(object):
                 avg_paulis.append(Operator._measure_pauli_z(measured_results, pauli[1]))
                 avg += pauli[0] * avg_paulis[idx]
                 variance += (pauli[0] ** 2) * Operator._covariance(measured_results, pauli[1], pauli[1],
-                                                                  avg_paulis[idx], avg_paulis[idx])
+                                                                   avg_paulis[idx], avg_paulis[idx])
 
         elif operator_mode == 'grouped_paulis':
             self._check_representation("grouped_paulis")
@@ -682,7 +679,7 @@ class Operator(object):
                     for pauli_2_idx, pauli_2 in enumerate(tpb_set):
                         variance += pauli_1[0] * pauli_2[0] * \
                             Operator._covariance(measured_results, pauli_1[1], pauli_2[1],
-                                                avg_paulis[pauli_1_idx], avg_paulis[pauli_2_idx])
+                                                 avg_paulis[pauli_1_idx], avg_paulis[pauli_2_idx])
 
         std_dev = np.sqrt(variance / num_shots)
 
@@ -1451,20 +1448,41 @@ class Operator(object):
     def find_Z2_symmetries(self):
         """
         Finds Z2 Pauli-type symmetries of a Operator
-        
+
         Returns:
-            [Pauli]: the list of Pauli objects representing the Z2 symmetries 
+            [Pauli]: the list of Pauli objects representing the Z2 symmetries
         """
 
         stacked_paulis = []
         for pauli in self._paulis:
-            stacked_paulis.append(np.concatenate( (pauli[1].v, pauli[1].w), axis=0))
-        
+            stacked_paulis.append(np.concatenate((pauli[1].v, pauli[1].w), axis=0))
+
         stacked_matrix = np.array(np.stack(stacked_paulis))
         symmetries = Operator.kernel_F2(stacked_matrix)
 
         Pauli_symmetries = []
         for symmetry in symmetries:
-            Pauli_symmetries.append(Pauli(symmetry[self.num_qubits:],symmetry[0:self.num_qubits]))
+            Pauli_symmetries.append(Pauli(symmetry[self.num_qubits:], symmetry[0:self.num_qubits]))
 
-        return Pauli_symmetries 
+        return Pauli_symmetries
+
+    def zeros_coeff_elimination(self):
+        """
+        Elinminate paulis or grouped paulis whose coefficients are zeros.
+
+        The difference from `_simplify_paulis` method is that, this method will not remove duplicated
+        paulis.
+        """
+        if self._paulis is not None:
+            new_paulis = []
+            for pauli in self._paulis:
+                if pauli[0] != 0:
+                    new_paulis.append(pauli)
+            self._paulis = new_paulis
+            self._paulis_table = {pauli[1].to_label(): i for i, pauli in enumerate(self._paulis)}
+
+        elif self._grouped_paulis is not None:
+            self._grouped_paulis_to_paulis()
+            self.zeros_coeff_elimination()
+            self._paulis_to_grouped_paulis()
+            self._paulis = None

--- a/qiskit_acqua/operator.py
+++ b/qiskit_acqua/operator.py
@@ -1409,13 +1409,13 @@ class Operator(object):
         matrix_out_temp = copy.deepcopy(matrix_in)
         indices = []
         matrix_out = np.zeros(size)
-        
+
         for i in range(size[0] - 1):
             if np.array_equal(matrix_out_temp[i, :], np.zeros(size[1])):
                 indices.append(i)
         for row in np.sort(indices)[::-1]:
             matrix_out_temp = np.delete(matrix_out_temp, (row), axis=0)
-                
+
         matrix_out[0:size[0] - len(indices), :] = matrix_out_temp
         matrix_out = matrix_out.astype(int)
 
@@ -1428,7 +1428,7 @@ class Operator(object):
 
         Args:
             matrix_in (np.ndarray): binary matrix
-            
+
         Returns:
             [np.ndarray]: the list of kernel vectors
         """
@@ -1474,10 +1474,7 @@ class Operator(object):
         paulis.
         """
         if self._paulis is not None:
-            new_paulis = []
-            for pauli in self._paulis:
-                if pauli[0] != 0:
-                    new_paulis.append(pauli)
+            new_paulis = [pauli for pauli in self._paulis if pauli[0] != 0]
             self._paulis = new_paulis
             self._paulis_table = {pauli[1].to_label(): i for i, pauli in enumerate(self._paulis)}
 

--- a/test/test_operator.py
+++ b/test/test_operator.py
@@ -191,6 +191,7 @@ class TestOperator(QISKitAcquaTestCase):
         opA = Operator(paulis=[pauli_term_a])
         opB = Operator(paulis=[pauli_term_b])
         newOP = opA + opB
+        newOP.zeros_coeff_elimination()
 
         self.assertEqual(0, len(newOP.paulis), "{}".format(newOP.print_operators()))
 
@@ -205,8 +206,18 @@ class TestOperator(QISKitAcquaTestCase):
         for i in range(6):
             opA = Operator(paulis=[[-coeffs[i], label_to_pauli(paulis[i])]])
             op += opA
+            op.zeros_coeff_elimination()
             self.assertEqual(6-(i+1), len(op.paulis))
 
+    def test_zero_elimination(self):
+        pauli_a = 'IXYZ'
+        coeff_a = 0.0
+        pauli_term_a = [coeff_a, label_to_pauli(pauli_a)]
+        opA = Operator(paulis=[pauli_term_a])
+        self.assertEqual(1, len(opA.paulis), "{}".format(opA.print_operators()))
+        opA.zeros_coeff_elimination()
+
+        self.assertEqual(0, len(opA.paulis), "{}".format(opA.print_operators()))
 
     def test_dia_matrix(self):
         """


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Speed up the operator
## Description
<!--- Describe your changes in detail -->
One factor slows down the speed is that removing paulis with zero coefficient during addition, when the to-be-added Operator has the periodic pattern, like +aP1, -aP1, +bP2, -bP2, it costs too much time in reconstructing the lookup table.

Thus, the changes:
1. skip removing paulis with zero coefficient in addition
2. separate a new method to eliminate zeros `zero_coeff_elimination`
3. update the `_simplify_paulis`


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Speed improvement.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

With acqua-chemistry, the following configuration are tested on macOS 10.13 with Python 3.6.5

|                                              | Orignal     | This commit |
|----------------------------------------------|-------------|-------------|
| LiH, ccpvdz basis => 38 qubits, 77930 paulis | 1538.33 sec | 496.85 sec  |
| H2, ccpvtz basis => 56 qubits, 187993 paulis | > 11000 sec | 1846.97 sec |

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.